### PR TITLE
mask icons in reply bars

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -37,9 +37,11 @@ chrome.runtime.onMessage.addListener(() => {
       }
       nameElem.textContent = replaceName;
 
-      const imgElem = item.querySelector("img");
-      imgElem.src = chrome.runtime.getURL(`images/${replaceName}.svg`);
-      imgElem.srcset = chrome.runtime.getURL(`images/${replaceName}.svg`);
+      const imgs = item.querySelectorAll(".c-base_icon");
+      imgs.forEach((imgElem) => {
+        imgElem.src = chrome.runtime.getURL(`images/${replaceName}.svg`);
+        imgElem.srcset = chrome.runtime.getURL(`images/${replaceName}.svg`);
+      });
     });
   };
 


### PR DESCRIPTION
Fixed icons in reply bars that were not masked.
The same icon is assigned to the same user in the main icon, but this fix does not take that into account.

<img width="532" alt="" src="https://user-images.githubusercontent.com/26921592/208001316-dab0e2a2-2a8b-419d-9644-186b259a7488.png">
